### PR TITLE
fix: update path to follow AW conventions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -164,6 +164,7 @@ enum Commands {
 // Configuration loading functions
 fn get_default_config_path() -> PathBuf {
     let mut path = dirs::config_dir().unwrap_or_else(|| PathBuf::from("."));
+    path.push("activitywatch");
     path.push("aw-notify");
     path.push("config.toml");
     path


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Updated the default configuration location to nest under an "activitywatch" directory. New installations will create configs in the new path. Existing users may need to move or copy their current configuration files to the updated location to ensure settings are applied. This affects all supported platforms and does not impact runtime behavior beyond where configuration files are read from by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->