### PR TITLE
feat: switch --output-only to JSON Lines format

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1012,11 +1012,14 @@ fn notify(title: &str, message: &str) -> Result<()> {
     let output_only = OUTPUT_ONLY.load(Ordering::Relaxed);
 
     if output_only {
-        // Output only mode - print to stdout with separators
-        println!("{}", "-".repeat(50));
-        println!("{}:", title);
-        println!("{}", message);
-        println!("{}", "-".repeat(50));
+        // Output only mode - print as JSON Lines format
+        let notification = serde_json::json!({
+            "timestamp": Utc::now().to_rfc3339(),
+            "title": title,
+            "message": message,
+            "app": "ActivityWatch",
+        });
+        println!("{}", serde_json::to_string(&notification)?);
         return Ok(());
     }
 


### PR DESCRIPTION
- Replace plain text format with newline-delimited JSON
- Each notification is now a JSON object with:
  - timestamp (ISO 8601)
  - title
  - message
  - app name
- Much easier to parse programmatically
- Better for integration with tools like aw-tauri
- Still human-readable when formatted

Example output:
{"timestamp":"2026-01-16T08:12:18.721738+00:00","title":"Time today","message":"- 💼 Work: 39m\n- 📱 Media: 6m","app":"ActivityWatch"}

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modified notification output format from plain text with separators to JSON Lines format, including timestamp, title, message, and app information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->