### PR TITLE
fix: disable HTTP notification server by default

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -23,7 +23,8 @@ productivity_score = true
 # Port for the local HTTP API that other modules use to send notifications
 # (POST http://127.0.0.1:<http_port>/notify). See the README section
 # "Sending notifications from other modules".
-http_port = 5667
+# Disabled by default (http_port = 0). Set to 5667 (or any free port) to enable.
+http_port = 0
 
 # Category alerts configuration
 # Each alert monitors a specific category and sends notifications when thresholds are reached

--- a/src/main.rs
+++ b/src/main.rs
@@ -132,7 +132,7 @@ impl Default for NotificationConfig {
             new_day_greetings: true,
             server_monitoring: true,
             productivity_score: true,
-            http_port: DEFAULT_PORT,
+            http_port: 0,
         }
     }
 }
@@ -394,7 +394,14 @@ fn start_service(hostname: String, config: NotificationConfig) -> Result<()> {
         log::info!("Server monitoring disabled in configuration");
     }
 
-    start_http_server(shutdown_rx_http, config.http_port);
+    if config.http_port != 0 {
+        start_http_server(shutdown_rx_http, config.http_port);
+    } else {
+        log::info!(
+            "HTTP notification server disabled (set http_port = {} in config to enable)",
+            DEFAULT_PORT
+        );
+    }
 
     // Main threshold monitoring loop (matching Python's threshold_alerts function)
     let result = threshold_alerts(shutdown_rx_main, config.alerts);


### PR DESCRIPTION
Closes #27

## Summary

The HTTP server (POST `/notify` endpoint, default port 5667) previously started unconditionally on every launch. This adds a surprise HTTP daemon to the default ActivityWatch distribution — exactly the concern raised in #27.

**This PR disables it by default.** The server only starts when `http_port` is set to a non-zero value in the config.

## Changes

- `NotificationConfig::default()` now uses `http_port: 0` instead of `DEFAULT_PORT`
- `start_http_server` is wrapped in the same conditional pattern already used by `hourly_checkins`, `new_day_greetings`, `server_monitoring`, and `productivity_score`
- `config.example.toml` updated to reflect the new default and explain how to opt in

## How to enable

```toml
# ~/.config/aw-notify/config.toml
http_port = 5667  # or any free port
```

## What this does NOT change

The `aw-notify-client` crate is unaffected — it still targets port 5667 by default. Modules using the client library will get a connection error if aw-notify's HTTP server isn't enabled, which is the appropriate behavior (opt-in feature → explicit configuration required).

The long-term bucket/SSE design from #27 remains the right direction, but this PR gives the immediate "no surprise HTTP server" fix without blocking on that infrastructure work.